### PR TITLE
add unbound config for localhost

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -1,0 +1,105 @@
+# Unbound config for localhost using DNS over TLS (DOT)
+
+# Before using the config, ensure the the following parameters are set correctly:
+## Install ca-certificates packages and set tls-cert-bundle
+## Fetch root root hints from https://www.internic.net/domain/named.cache and set root-hints
+## Set trust-anchor-file. Use the unbound-anchor program bundled with unbound
+
+# The server clause sets the main parameters.
+server:
+	# verbosity number, 0 is least verbose. 1 is default.
+	verbosity: 1
+
+	# number of threads to create. 1 disables threading.
+	num-threads: 1
+
+	# specify the interfaces to answer queries from by ip-address.
+	# The default is to listen to localhost (127.0.0.1 and ::1).
+	# specify 0.0.0.0 and ::0 to bind to all available interfaces.
+	# specify every interface[@port] on a new 'interface:' labelled line.
+	# The listen interfaces are not changed on reload, only on restart.
+	interface: 127.0.0.1
+	interface: ::1
+
+	# port to answer queries from
+	port: 53
+
+	# the time to live (TTL) value lower bound, in seconds. Default 0.
+	# If more than an hour could easily give trouble due to stale data.
+	cache-min-ttl: 0
+
+	# the time to live (TTL) value cap for RRsets and messages in the
+	# cache. Items are not cached for longer. In seconds.
+	cache-max-ttl: 86400
+
+	# Enable IPv4, "yes" or "no".
+	do-ip4: yes
+
+	# Enable IPv6, "yes" or "no".
+	do-ip6: yes
+
+	# control which clients are allowed to make (recursive) queries
+	# to this server. Specify classless netblocks with /size and action.
+	# By default everything is refused, except for localhost.
+	# Choose deny (drop message), refuse (polite error reply),
+	# allow (recursive ok), allow_setrd (recursive ok, rd bit is forced on),
+	# allow_snoop (recursive and nonrecursive ok)
+	# deny_non_local (drop queries unless can be answered from local-data)
+	# refuse_non_local (like deny_non_local but polite error reply).
+
+  # Only allow localhost
+	access-control: 0.0.0.0/0 refuse
+	access-control: ::0/0 refuse
+	access-control: 127.0.0.1/32 allow
+	access-control: ::1/128 allow
+
+	# file to read root hints from.
+	# get one from https://www.internic.net/domain/named.cache
+	root-hints: "/etc/unbound/named.cache"
+
+	# enable to not answer id.server and hostname.bind queries.
+	hide-identity: yes
+
+	# enable to not answer version.server and version.bind queries.
+	hide-version: yes
+
+	# File with trusted keys for validation. Specify more than one file
+	# with several entries, one file per entry.
+	# Zone file format, with DS and DNSKEY entries.
+	# Note this gets out of date, use auto-trust-anchor-file please.
+	trust-anchor-file: "/etc/unbound/trusted-key.key"
+
+	# service clients over TLS (on the TCP sockets) with plain DNS inside
+	# the TLS stream, and over HTTPS using HTTP/2 as specified in RFC8484.
+	# Give the certificate to use and private key.
+	# default is "" (disabled).  requires restart to take effect.
+	# tls-service-key: "path/to/privatekeyfile.key"
+	# tls-service-pem: "path/to/publiccertfile.pem"
+	#tls-port: 853
+	#https-port: 443
+
+	# cipher setting for TLSv1.2
+	# tls-ciphers: "DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+	# Cipher setting for TLSv1.3
+	# Selected from https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf
+	tls-ciphersuites: "TLS_AES_128_GCM_SHA256:TLS_AES_128_CCM_8_SHA256:TLS_AES_128_CCM_SHA256:TLS_AES_256_GCM_SHA384"
+
+	# request upstream over TLS (with plain DNS inside the TLS stream).
+	# Default is no.  Can be turned on and off with unbound-control.
+	tls-upstream: yes
+
+	# Certificates used to authenticate connections made upstream.
+	tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
+
+# Forward zones
+# Solve recursively from specified name servers
+## UncensoredDNS
+forward-zone:
+	name: "."
+	forward-tls-upstream: yes
+	forward-first: no
+	forward-no-cache: no
+	forward-addr: 91.239.100.100@853#anycast.censurfridns.dk
+	forward-addr: 2001:67c:28a4::@853#anycast.censurfridns.dk
+	forward-addr: 89.233.43.71@853#unicast.censurfridns.dk
+	forward-addr: 2a01:3a0:53:53::@853#unicast.censurfridns.dk


### PR DESCRIPTION
Add unbound config that uses DNS over TLS (DOT) pointing to [uncensoreddns.org](https://blog.uncensoreddns.org/) and access-control set to only allow localhost.

As noted in the config, three things have to be set correctly before the resolver behaves as intented:
- Install ca-certificates packages and set tls-cert-bundle
- Fetch root root hints from https://www.internic.net/domain/named.cache and set root-hints
- Set trust-anchor-file. Use the unbound-anchor program bundled with unbound