### PR TITLE
Fix DoH address for Firefox

### DIFF
--- a/firefox.md
+++ b/firefox.md
@@ -11,6 +11,6 @@
 ![Click Settings under Network Settings](screenshots/ff_4.png?raw=true "Click Settings under Network Settings")
 5. Tick "_**Enable DNS over HTTPS**_" if it is not already ticked.
 6. Under the "_Use Provider_" dropdown menu, select "_**Custom**_".
-7. In the "_Custom_" text field, enter ´anycast.censurfridns.dk´
+7. In the "_Custom_" text field, enter `https://anycast.uncensoreddns.org/dns-query`
 ![Enable DNS Over HTTPS, select custom provider and enter URL](screenshots/ff_5.png?raw=true "Enable DNS Over HTTPS, select custom provider and enter URL")
 8. Click "**_OK_**" and restart Firefox 


### PR DESCRIPTION
DNS-over-HTTPS addresses entered in the Firefox settings should be absolute URLs, otherwise they will be silently ignored (tested on FF 105.0.2 @ Linux).
This commit changes the DoH address mentioned in the Firefox guide from `anycast.censurfridns.dk` to `https://anycast.uncensoreddns.org/dns-query` so that it matches the screenshot.