### PR TITLE
OpenWrt: Add Uncensored DNS to the web interface

### DIFF
--- a/openwrt.md
+++ b/openwrt.md
@@ -12,8 +12,52 @@ into the router or using the web interface).
 
 The luci package will allow you to change some settings via the web
 interface. Unfortunately, it only allows you to select predefined DoH
-providers. Thus, in order to add Uncensored DNS as a provider, you need
-to SSH into the router and edit the file `/etc/config/https-dns-proxy`
+providers.
+
+You can either
+- Add Uncensored DNS to the list of predefined DoH providers in the LuCi web interface, or
+- Edit the configuration file.
+
+
+## Add Uncensored DNS to the list of predefined DoH providers in the web interface
+
+SSH into the router and add the file `/usr/lib/lua/luci/https-dns-proxy/providers/org.uncensoreddns.anycast.lua` with contents similar to
+
+```
+return {
+	name = "anycast.uncensoreddns.org",
+	label = _("Uncensored DNS (anycast)"),
+	resolver_url = "https://anycast.uncensoreddns.org/dns-query",
+	bootstrap_dns = "208.67.222.222,208.67.220.220",
+	help_link = "https://blog.uncensoreddns.org/dns-servers/",
+	help_link_text = "uncensoreddns.org"
+}
+```
+
+and add the file `/usr/lib/lua/luci/https-dns-proxy/providers/org.uncensoreddns.unicast.lua` with contents similar to
+
+```
+return {
+	name = "unicast.uncensoreddns.org",
+	label = _("Uncensored DNS (unicast)"),
+	resolver_url = "https://unicast.uncensoreddns.org/dns-query",
+	bootstrap_dns = "208.67.222.222,208.67.220.220",
+	help_link = "https://blog.uncensoreddns.org/dns-servers/",
+	help_link_text = "uncensoreddns.org"
+}
+```
+
+Now you can select the Uncensored DNS DoH provider in the LuCi web interface.
+
+Please note that the _OpenDNS_ DNS servers are used for bootstrapping in
+this example. These are only used for the initial unencrypted lookup of
+the DNS records for the resolvers. You can change this to something
+else, if you prefer another provider.
+
+
+## Edit the configuration file
+
+You can also SSH into the router and edit the file `/etc/config/https-dns-proxy`
 
 An example configuration could look like this:
 
@@ -42,7 +86,7 @@ Save the file and reload the `https-dns-proxy` service. If all goes
 well, this is all you need to do.
 
 
-## Warning about the _DNS HTTPS Proxy_ service page in the web interface
+### Warning about the _DNS HTTPS Proxy_ service page in the web interface
 
 After reloading the service, the Uncensored DNS servers will be listed
 as "Unknown Provider DoH" under _Service Status_. Even worse, the 2


### PR DESCRIPTION
Add instructions to add Uncensored DNS as a predefined provider / resolver in the LuCi web interface.

This improves the experience when using the web interface; you can safely press the _Save & Apply_ button.

If you wish, you can add Uncensored DNS to the official list of known providers circa here: https://github.com/openwrt/luci/tree/openwrt-22.03/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers I am not sure if you are interested in the added attention and traffic?